### PR TITLE
added more flags to the CLI to select players

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 )
 
 var reps int
-
+var oplayer, xplayer string
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use: "oxocli",
@@ -35,8 +35,8 @@ func Execute() {
 }
 
 func flagsFunc(cmd *cobra.Command, args []string) {
-	fmt.Printf("p = %d\n", reps)
-	fmt.Println("args:", args)
+//	fmt.Printf("p = %d\n", reps)
+//	fmt.Println("args:", args)
 	nl := oxo.Newlookup()
 
 //Now to add these to a new data structure, a Result, which will be a slice of Games.
@@ -44,10 +44,13 @@ func flagsFunc(cmd *cobra.Command, args []string) {
 var res oxo.Group
 var flipwhostarts bool
 
+playerlookup:=oxo.NewPlayerlookup()
+
+
 for i := 0; i < reps; i++ {
-	flipwhostarts = !flipwhostarts                         //alternates who starts the game eliminating any first mover advantage
-	OPlayer := oxo.Player{"RANDOM", oxo.Corner, 0}         //Setup O
-	XPlayer := oxo.Player{"RANDOM", oxo.Random, 0}         //Setup X
+	flipwhostarts = !flipwhostarts           //alternates who starts the game eliminating any first mover advantage
+	OPlayer := playerlookup[oplayer]        //Setup O looksup the string entered at the command line for -o to finds the player 
+	XPlayer := playerlookup[xplayer]        //Setup X looksup the string entered at the command line for -x to finds the player 
 	x := oxo.Playgame(nl, OPlayer, XPlayer, flipwhostarts) //PlayGame, toss coin to decide who goes first...
 	res.Games = append(res.Games, x)                       //Add Game to res slice.
 	res.UpdateNums(x)
@@ -59,6 +62,7 @@ fmt.Printf("Printed %d games\n\n",reps)
 fmt.Printf(" Number of XWINS = %d\n", res.NumXwins)
 fmt.Printf(" Number of OWINS = %d\n", res.NumOwins)
 fmt.Printf(" Number of DRAWS = %d\n", res.NumDraws)
+fmt.Printf(" Number of ILLEGALS = %d\n", res.NumIllegals)
 
 }
 func init() {
@@ -71,5 +75,7 @@ func init() {
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	rootCmd.Flags().IntVarP(&reps, "numgames", "n", 1, "number of games to play")
+	rootCmd.Flags().StringVarP(&oplayer, "oplayer", "o", "RANDOM", "O player,  select a tactic RANDOM, CENTRE. CORNER....")
+	rootCmd.Flags().StringVarP(&xplayer, "xplayer", "x", "RANDOM", "X player. select a tactic RANDOM, CENTRE. CORNER....")
 	//rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/oxo/lookup.go
+++ b/oxo/lookup.go
@@ -1,5 +1,6 @@
 package oxo
 
+
 // Newlookup returns a lookup table that has a 9 character string as key that represents the OXO board and value string that indicates its state
 func Newlookup() map[string]string {
 
@@ -126,4 +127,15 @@ func convert(j int) string {
 		return " "
 	}
 	return "?"
+}
+
+//This will be used for creating a Player from a command line string flag 
+func NewPlayerlookup() map[string]Player {
+	pl := make(map[string]Player)
+	pl["RANDOM"]=Player{Name: "RANDOM", Tactic: Random, Rank: 0}
+    pl["CORNER"]=Player{Name: "CORNER", Tactic: Corner, Rank: 0}
+    pl["CENTRE"]=Player{Name: "CENTRE", Tactic: Centre, Rank: 0}
+	pl["COMPLETEXLINE"]=Player{Name: "COMPLETEXLINE", Tactic: CompleteXLine, Rank: 0}
+	pl["COMPLETEOLINE"]=Player{Name: "COMPLETEOLINE", Tactic: CompleteOLine, Rank: 0}
+	return pl
 }

--- a/oxo/tactics.go
+++ b/oxo/tactics.go
@@ -3,7 +3,6 @@ package oxo
 import (
 	"math/rand"
 )
-
 // Random is a tactic returning an int that is its chosen location on the grid
 // Findspaces finds the spaces on the Grid and Random choses one....randomly
 func Random(g Grid) int {

--- a/oxo/types.go
+++ b/oxo/types.go
@@ -82,6 +82,7 @@ type Group struct {
 	NumOwins int
 	NumXwins int
 	NumDraws int
+	NumIllegals int
 	NumTurns int
 }
 
@@ -93,6 +94,8 @@ func (r *Group) UpdateNums(g Game) {
 		r.NumOwins++
 	case g.Result == "DRAW":
 		r.NumDraws++
+	case g.Result == "ILLEGAL":
+		r.NumIllegals++
 	}
 	r.NumTurns = len(g.Turns)
 	return


### PR DESCRIPTION
Now with command line flags to select o and x players that use different tactics.

Added a lookup table for players to match a string obtained from a command line flag against a map of available players.

A player is then created for O and X and configured with a tactic function taken from the command line  and looked up in the new players lookup table


